### PR TITLE
Fix autogenerated prompt.default.file path

### DIFF
--- a/svx/core/config.py
+++ b/svx/core/config.py
@@ -291,7 +291,7 @@ def init_user_config(force: bool = False, prompt_file: Path | None = None) -> Pa
         "[prompt.default]\n"
         "# Default user prompt source:\n"
         "# - Option 1: Use a file (recommended)\n"
-        f'file = "{str(prompt_file)}"\n'
+        f'file = "{prompt_file.as_posix()}"\n'
         "#\n"
         "# - Option 2: Inline prompt (less recommended for long text)\n"
         '# text = "Please transcribe the audio and provide a concise summary in French."\n'


### PR DESCRIPTION
Fix autogenerated `prompt.default.file` path to use a Windows-compatible TOML string on Windows, while keeping the path correct as-is on Linux and MacOS. Before, the string contained backslashes on Windows (see #1) and they need to be escaped (or not used) in TOML.

The fix uses `as_posix()` to write a path with forward slashes. This is valid TOML (no backslash escaping issues) and `Path()` on Windows resolves it correctly.

This seemed a cleaner solution that escaping the backslashes as suggested before in #1.

Closes #1